### PR TITLE
MOSIP-34839 - Fix wrong geolocation assignment. (#213)

### DIFF
--- a/pre-registration-ui/src/app/feature/booking/center-selection/center-selection.component.ts
+++ b/pre-registration-ui/src/app/feature/booking/center-selection/center-selection.component.ts
@@ -383,7 +383,7 @@ export class CenterSelectionComponent
     if ("geolocation" in navigator) {
       this.showMap = false;
       this.positions = navigator.geolocation;
-      this.positions.geolocation.getCurrentPosition((position) => {
+      this.positions.getCurrentPosition((position) => {
         console.log(position.coords);
         const subs = this.dataService
           .getNearbyRegistrationCenters(position.coords)


### PR DESCRIPTION
Root Cause:
- After MOSIP-32289, the code incorrectly accessed, because navigator.geolocation was assigned to this.positions, then re-accessed as if it had a .geolocation property, which caused a TypeError.

Fix:
- Keep Assign navigator.geolocation to this.position field.
- Directly call getCurrentPosition() on the assigned object this.position.

Already merged in <develop> in [PR#213](https://github.com/mosip/pre-registration-ui/pull/213)